### PR TITLE
Add Flutter AI chatbot project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # CHATBOTGCI
+
+Ce dépôt contient un exemple d'application Flutter d'intelligence artificielle.
+Consultez le dossier `flutter_ai_chatbot` pour le code de l'application.

--- a/flutter_ai_chatbot/.gitignore
+++ b/flutter_ai_chatbot/.gitignore
@@ -1,0 +1,7 @@
+build/
+.dart_tool/
+.packages
+.pub/
+.idea/
+.android/
+.ios/

--- a/flutter_ai_chatbot/README.md
+++ b/flutter_ai_chatbot/README.md
@@ -1,0 +1,11 @@
+# Flutter AI Chatbot
+
+Application Flutter d'exemple utilisant l'API OpenAI pour fournir un chatbot sp\u00e9cialis\u00e9 en g\u00e9nie civil.
+
+## D\u00e9marrage rapide
+
+1. Ajoutez votre cl\u00e9 API dans `lib/config.dart`.
+2. Ex\u00e9cutez `flutter pub get`.
+3. Lancez l'application avec `flutter run` sur un dispositif ou émulateur.
+
+Assurez-vous que votre projet dispose d'un acc\u00e8s internet pour les requ\u00eates API.

--- a/flutter_ai_chatbot/android/app/src/main/AndroidManifest.xml
+++ b/flutter_ai_chatbot/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,24 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.flutter_ai_chatbot">
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <application
+        android:label="flutter_ai_chatbot"
+        android:icon="@mipmap/ic_launcher">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:launchMode="singleTop"
+            android:theme="@style/LaunchTheme"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenSize|locale|layoutDirection"
+            android:hardwareAccelerated="true"
+            android:windowSoftInputMode="adjustResize">
+            <meta-data
+                android:name="io.flutter.embedding.android.NormalTheme"
+                android:resource="@style/NormalTheme"/>
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/flutter_ai_chatbot/lib/config.dart
+++ b/flutter_ai_chatbot/lib/config.dart
@@ -1,0 +1,1 @@
+const String API_KEY = 'TA_CLE_API'; // Remplace par ta vraie clé

--- a/flutter_ai_chatbot/lib/main.dart
+++ b/flutter_ai_chatbot/lib/main.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'services/ai_service.dart';
+import 'services/chat_provider.dart';
+import 'screens/chat_screen.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider(
+      create: (_) => ChatProvider(AIService()),
+      child: MaterialApp(
+        title: 'Flutter AI Chatbot',
+        theme: ThemeData(
+          useMaterial3: true,
+          brightness: Brightness.light,
+          colorSchemeSeed: Colors.indigo,
+        ),
+        darkTheme: ThemeData(
+          useMaterial3: true,
+          brightness: Brightness.dark,
+          colorSchemeSeed: Colors.indigo,
+        ),
+        themeMode: ThemeMode.system,
+        home: const ChatScreen(),
+      ),
+    );
+  }
+}

--- a/flutter_ai_chatbot/lib/models/message.dart
+++ b/flutter_ai_chatbot/lib/models/message.dart
@@ -1,0 +1,6 @@
+class Message {
+  final String role;
+  final String content;
+
+  Message({required this.role, required this.content});
+}

--- a/flutter_ai_chatbot/lib/screens/chat_screen.dart
+++ b/flutter_ai_chatbot/lib/screens/chat_screen.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../services/chat_provider.dart';
+import '../models/message.dart';
+import '../widgets/error_message.dart';
+
+class ChatScreen extends StatefulWidget {
+  const ChatScreen({Key? key}) : super(key: key);
+
+  @override
+  State<ChatScreen> createState() => _ChatScreenState();
+}
+
+class _ChatScreenState extends State<ChatScreen> {
+  final TextEditingController _controller = TextEditingController();
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = Provider.of<ChatProvider>(context);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scrollController.hasClients) {
+        _scrollController.jumpTo(_scrollController.position.maxScrollExtent);
+      }
+    });
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Chatbot G\u00e9nie Civil IA'),
+        centerTitle: true,
+      ),
+      body: SafeArea(
+        child: Column(
+          children: [
+            Expanded(
+              child: ListView.builder(
+                controller: _scrollController,
+                padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+                itemCount: provider.messages.length,
+                itemBuilder: (context, index) {
+                  final Message msg = provider.messages[index];
+                  final isUser = msg.role == 'user';
+                  return Align(
+                    alignment:
+                        isUser ? Alignment.centerRight : Alignment.centerLeft,
+                    child: Container(
+                      margin: const EdgeInsets.symmetric(vertical: 4),
+                      padding: const EdgeInsets.all(12),
+                      decoration: BoxDecoration(
+                        color: isUser
+                            ? Theme.of(context).colorScheme.primaryContainer
+                            : Theme.of(context).colorScheme.secondaryContainer,
+                        borderRadius: BorderRadius.only(
+                          topLeft: const Radius.circular(16),
+                          topRight: const Radius.circular(16),
+                          bottomLeft:
+                              Radius.circular(isUser ? 16 : 0),
+                          bottomRight:
+                              Radius.circular(isUser ? 0 : 16),
+                        ),
+                        boxShadow: [
+                          BoxShadow(
+                            color: Colors.black.withOpacity(0.05),
+                            offset: const Offset(0, 1),
+                            blurRadius: 2,
+                          ),
+                        ],
+                      ),
+                      child: Text(
+                        msg.content,
+                        style: TextStyle(
+                          color: isUser
+                              ? Theme.of(context)
+                                  .colorScheme
+                                  .onPrimaryContainer
+                              : Theme.of(context)
+                                  .colorScheme
+                                  .onSecondaryContainer,
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+            if (provider.isLoading)
+              const Padding(
+                padding: EdgeInsets.all(8.0),
+                child: CircularProgressIndicator(),
+              ),
+            if (provider.error != null) ErrorMessage(provider.error!),
+            Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: TextField(
+                      controller: _controller,
+                      decoration: InputDecoration(
+                        hintText: 'Ecrire votre question',
+                        filled: true,
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(24),
+                          borderSide: BorderSide.none,
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  FilledButton(
+                    onPressed: provider.isLoading
+                        ? null
+                        : () {
+                            final text = _controller.text;
+                            _controller.clear();
+                            provider.send(text);
+                          },
+                    child: const Icon(Icons.send),
+                  )
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_ai_chatbot/lib/services/ai_service.dart
+++ b/flutter_ai_chatbot/lib/services/ai_service.dart
@@ -1,0 +1,36 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import '../config.dart';
+
+class AIService {
+  final String endpoint = 'https://api.openai.com/v1/chat/completions';
+
+  Future<String> sendMessage(String question) async {
+    final response = await http
+        .post(
+          Uri.parse(endpoint),
+          headers: {
+            'Authorization': 'Bearer $API_KEY',
+            'Content-Type': 'application/json',
+          },
+          body: jsonEncode({
+            'model': 'gpt-3.5-turbo',
+            'messages': [
+              {
+                'role': 'system',
+                'content': 'Tu es un assistant expert en g\u00e9nie civil.'
+              },
+              {'role': 'user', 'content': question}
+            ]
+          }),
+        )
+        .timeout(const Duration(seconds: 10));
+
+    if (response.statusCode == 200) {
+      final data = jsonDecode(response.body);
+      return data['choices'][0]['message']['content'];
+    } else {
+      throw Exception('Erreur ${response.statusCode}');
+    }
+  }
+}

--- a/flutter_ai_chatbot/lib/services/chat_provider.dart
+++ b/flutter_ai_chatbot/lib/services/chat_provider.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import '../models/message.dart';
+import 'ai_service.dart';
+
+class ChatProvider extends ChangeNotifier {
+  final AIService _service;
+  final List<Message> _messages = [];
+  bool _isLoading = false;
+  String? _error;
+
+  ChatProvider(this._service);
+
+  List<Message> get messages => _messages;
+  bool get isLoading => _isLoading;
+  String? get error => _error;
+
+  Future<void> send(String text) async {
+    if (text.trim().isEmpty) return;
+    _messages.add(Message(role: 'user', content: text));
+    _isLoading = true;
+    _error = null;
+    notifyListeners();
+    try {
+      final reply = await _service.sendMessage(text);
+      _messages.add(Message(role: 'assistant', content: reply));
+    } catch (e) {
+      _error = 'Erreur lors de la requ\u00eate';
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+}

--- a/flutter_ai_chatbot/lib/widgets/error_message.dart
+++ b/flutter_ai_chatbot/lib/widgets/error_message.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+class ErrorMessage extends StatelessWidget {
+  final String message;
+  const ErrorMessage(this.message, {Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(8),
+      margin: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.errorContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.error, color: Theme.of(context).colorScheme.onError),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              message,
+              style:
+                  TextStyle(color: Theme.of(context).colorScheme.onError),
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/flutter_ai_chatbot/pubspec.yaml
+++ b/flutter_ai_chatbot/pubspec.yaml
@@ -1,0 +1,20 @@
+name: flutter_ai_chatbot
+description: Chatbot IA en Flutter
+publish_to: 'none'
+version: 1.0.0+1
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  provider: ^6.0.0
+  http: ^0.13.0
+  cupertino_icons: ^1.0.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- create Flutter AI Chatbot sample project
- add state management with provider
- provide OpenAI API call logic
- implement simple UI with chat bubbles and error display
- enhance chat UI with Material 3 theming and refined bubbles

## Testing
- `dart format lib/main.dart lib/screens/chat_screen.dart lib/widgets/error_message.dart` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6876c8ad52788331a1fc5508dd1116be